### PR TITLE
Don't log EOF error on sudden connection close

### DIFF
--- a/smtpd.go
+++ b/smtpd.go
@@ -522,8 +522,10 @@ func (c *Conn) readCmd() string {
 	if err != nil || c.lr.N == 0 {
 		c.state = sAbort
 		line = ""
-		c.log("!", "command abort %s err: %v",
-			fmtBytesLeft(2048, c.lr.N), err)
+		if err != io.EOF {
+			c.log("!", "command abort %s err: %v",
+				fmtBytesLeft(2048, c.lr.N), err)
+		}
 	} else {
 		c.log("r", line)
 	}


### PR DESCRIPTION
If a client closes a connection before the `QUIT` command has been issued an EOF error will be reported when logging has been enabled like so:

```
! command abort 0 bytes read err: EOF
```

Since there appear to be a lot of clients out there who behave like this, catch the io.EOF error and silently close it. The `smtpd.ABORT` event will still be sent when this happens if you want to catch these situations on the implementaton side of things.